### PR TITLE
Channel users to the forum instead of Discord on the /community page, but still mention Discord & Slack to chat

### DIFF
--- a/layouts/community/single.html
+++ b/layouts/community/single.html
@@ -66,6 +66,21 @@
           <p class="subtitle">
             Come nerd out at the monthly <a href="https://www.meetup.com/nerves">Nerves Online Meetup</a>.
           </p>
+          <p class="subtitle">
+            You can also come chat in the #nerves channels on
+            <span class="icon-text">
+              <span class="icon">
+                <img src="{{ relURL "img/slack.svg" }}"></img>
+              </span>
+              <span><a href="https://elixir-slack.community/">Elixir Slack</a></span>
+            </span>, 
+            <span class="icon-text">
+              <span class="icon">
+                <img src="{{ relURL "img/discord.svg" }}"></img>
+              </span>
+              <span><a href="https://discord.gg/elixir">Elixir Discord</a></span>
+            </span>.
+          </p>
         </div>
       </div>
     </div>
@@ -90,22 +105,8 @@
             </span>
             to find previously answered questions or ask for help.
           </p>
-          <p class="subtitle">
-            You can also post to the #nerves channel on
-            <span class="icon-text">
-              <span class="icon">
-                <img src="{{ relURL "img/slack.svg" }}"></img>
-              </span>
-              <span><a href="https://elixir-slack.community/">Elixir Slack</a></span>
-            </span>, 
-            <span class="icon-text">
-              <span class="icon">
-                <img src="{{ relURL "img/discord.svg" }}"></img>
-              </span>
-              <span><a href="https://discord.gg/elixir">Elixir Discord</a></span>
-            </span>, 
-            or <a href="https://github.com/nerves-project/nerves/issues/new" target="_blank">submit a new issue</a> on GitHub.
-          </p>
+          <p class="subtitle">You can also
+            <a href="https://github.com/nerves-project/nerves/issues/new" target="_blank">submit a new issue</a> on GitHub.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Before : 

<img width="950" alt="Capture d’écran 2024-09-17 à 15 47 12" src="https://github.com/user-attachments/assets/fafe99bc-c374-4ec6-8763-be4ef0e4af94">


After :

<img width="980" alt="Capture d’écran 2024-09-17 à 15 47 08" src="https://github.com/user-attachments/assets/c5768177-0a95-433e-a5e6-a043c0b90b88">
