### PR TITLE
Update link to AtomVM website

### DIFF
--- a/content/code.md
+++ b/content/code.md
@@ -30,7 +30,7 @@ submit_issue: https://github.com/nerves-project/nerves/issues/new
 related_projects:
   - name: AtomVM
     image: 'img/AtomVM-logo.png'
-    link: https://atomvm.net/
+    link: https://atomvm.org/
     link_text: AtomVM Homepage
     description: |
       A minimum Erlang VM that runs on microcontrollers like ESP32 and STM32 devices

--- a/content/related_projects.md
+++ b/content/related_projects.md
@@ -7,7 +7,7 @@ tags: []
 options:
   - name: AtomVM
     image: 'img/AtomVM-logo.png'
-    link: https://atomvm.net/
+    link: https://atomvm.org/
     link_text: AtomVM Homepage
     description: |
       A minimum Erlang VM that runs on microcontrollers like ESP32 and STM32 devices


### PR DESCRIPTION
Old domain is being phased out, [atomvm.org](https://atomvm.org/) is the new one.